### PR TITLE
Add ccmod.json

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -1,0 +1,10 @@
+{
+	"id": "Extra Gamepad Options",
+	"version": "1.0.2",
+	"title": "Extra Gamepad Options",
+	"description": "Allows buttons/triggers to be swapped, and adds extra icon themes.",
+    "repository": "https://github.com/ubergeek77/CCExtraGamepadOptions",
+    "tags": ["QoL"],
+    "authors": "ubergeek77",
+	"prestart": "prestart.js"
+}


### PR DESCRIPTION
Hi!
I want to add your mod to a centralized mod repository called CCModDB (your mod was once there).
It will allow the upcoming in-game [mod manager](https://github.com/CCDirectLink/CCModManager) to see your mod and make it one-click-installable with all the dependencies.
It requires `ccmod.json` to be present.
Please create a new release after merging.